### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.17-bullseye AS build
+
+COPY vendor/ /usr/src/tftp-http-proxy/vendor/
+COPY Makefile main.go /usr/src/tftp-http-proxy/
+
+WORKDIR /usr/src/tftp-http-proxy
+
+ENV GO111MODULE=off
+RUN make
+
+FROM debian:bullseye-slim
+
+RUN apt-get update && apt-get install -y dumb-init gosu libcap2-bin
+
+COPY entrypoint.sh /usr/sbin/entrypoint.sh
+COPY --from=build /usr/src/tftp-http-proxy/dist/tftp-http-proxy /usr/bin/tftp-http-proxy
+
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/tftp-http-proxy
+
+ENTRYPOINT [ "/usr/sbin/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN make
 
 FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install -y dumb-init gosu libcap2-bin && apt-get clean
+RUN apt-get update && apt-get install -y ca-certificates dumb-init gosu libcap2-bin && apt-get clean
 
 COPY entrypoint.sh /usr/sbin/entrypoint.sh
 COPY --from=build /usr/src/tftp-http-proxy/dist/tftp-http-proxy /usr/bin/tftp-http-proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN make
 
 FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install -y dumb-init gosu libcap2-bin
+RUN apt-get update && apt-get install -y dumb-init gosu libcap2-bin && apt-get clean
 
 COPY entrypoint.sh /usr/sbin/entrypoint.sh
 COPY --from=build /usr/src/tftp-http-proxy/dist/tftp-http-proxy /usr/bin/tftp-http-proxy

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PUID=${PUID:-nobody}
+PGID=${PGID:-nogroup}
+
+exec /usr/bin/dumb-init /usr/sbin/gosu "$PUID:$PGID" /usr/bin/tftp-http-proxy "$@"


### PR DESCRIPTION
This PR adds a Dockerfile to build a container to run tftp-http-proxy.

There are many forks of this repo, but this seems to be the most viable one, so I am submitting the PR here.